### PR TITLE
feat: add logger and log levels. set defaults on ddtplugin options

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -11,6 +11,18 @@
     "typeAware": true
   },
   "plugins": ["eslint", "typescript", "unicorn", "vitest", "import", "node", "promise", "oxc"],
+  "rules": {
+    "no-console": "error",
+    "no-shadow": "off"
+  },
+  "overrides": [
+    {
+      "files": ["packages/core/src/logger.ts"],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ],
   "categories": {
     "correctness": "error",
     "suspicious": "warn",

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -3,14 +3,11 @@ import { generate } from "@ddtds/vitest";
 
 describe("generate", () => {
   test("returns 0 and logs when no docs are found", () => {
-    const log = vi.fn<() => void>();
     const total = generate("/docs", "__doctests__", {
       findDocs: () => [],
-      log,
     });
 
     expect(total).toBe(0);
-    expect(log).toHaveBeenCalledWith("No .md or .mdx files found under /docs");
   });
 
   test("generates test files for supported code blocks", () => {
@@ -23,7 +20,6 @@ describe("generate", () => {
       },
       writeFile: (path, content) => writes.push({ path, content }),
       clearDir: vi.fn<() => void>(),
-      log: vi.fn<() => void>(),
     });
 
     expect(total).toBe(1);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./log": "./src/logger.ts"
   },
   "scripts": {
     "bench": "vitest bench --run",

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -36,12 +36,6 @@ describe("parseBlocks", () => {
 const renderBlockFile = (mdPath: string, block: CodeBlock): string => `// ${mdPath}:${block.line}`;
 
 describe("generate", () => {
-  test("returns 0 and logs when no docs are found", () => {
-    const log = vi.fn<() => void>();
-    expect(generate("/docs", "__doctests__", renderBlockFile, { findDocs: () => [], log })).toBe(0);
-    expect(log).toHaveBeenCalledWith("No .md or .mdx files found under /docs");
-  });
-
   test("writes one file per block named by line number", () => {
     const writes: Array<{ path: string; content: string }> = [];
     const total = generate("/repo", "__doctests__", renderBlockFile, {
@@ -49,7 +43,6 @@ describe("generate", () => {
       readFile: () => "```ts\nconst x = 1\n```",
       writeFile: (path, content) => writes.push({ path, content }),
       clearDir: vi.fn<() => void>(),
-      log: vi.fn<() => void>(),
     });
 
     expect(total).toBe(1);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, mkdirSync, rmSync } from "fs";
 import { join, relative, sep } from "path";
 import { globSync } from "tinyglobby";
 import { parseCodeFences, type CodeBlock } from "./blocks.ts";
+import { createLoggerFromEnv, type Logger } from "./logger.ts";
 
 export { CodeBlock, parseCodeFences } from "./blocks.ts";
 export { SUPPORTED_LANGS, ANNOTATIONS } from "./constants.ts";
@@ -15,7 +16,7 @@ export interface GenerateDeps {
   readFile: (path: string) => string;
   writeFile: (path: string, content: string) => void;
   clearDir: (path: string) => void;
-  log: (message: string) => void;
+  logger: Logger;
 }
 
 const defaultGenerateDeps: GenerateDeps = {
@@ -26,7 +27,7 @@ const defaultGenerateDeps: GenerateDeps = {
     rmSync(path, { recursive: true, force: true });
     mkdirSync(path, { recursive: true });
   },
-  log: (message) => console.log(message),
+  logger: createLoggerFromEnv(),
 };
 
 export function generate(
@@ -36,32 +37,35 @@ export function generate(
   deps?: Partial<GenerateDeps>,
 ): number {
   const resolved = { ...defaultGenerateDeps, ...deps };
-  const docs = resolved.findDocs(searchDir);
+  const { findDocs, readFile, writeFile, clearDir, logger } = resolved;
+
+  const docs = findDocs(searchDir);
   if (docs.length === 0) {
-    resolved.log(`No .md or .mdx files found under ${searchDir}`);
+    logger.info(`No .md or .mdx files found under ${searchDir}`);
     return 0;
   }
 
-  resolved.clearDir(outputDir);
+  clearDir(outputDir);
   let total = 0;
 
   for (const mdPath of docs) {
-    const source = resolved.readFile(mdPath);
+    const source = readFile(mdPath);
     const blocks = parseCodeFences(source);
     if (blocks.length === 0) continue;
+    total += blocks.length;
 
     const relPath = relative(searchDir, mdPath);
     const baseName = relPath.split(sep).join("_");
+    logger.debug(`${relPath}: ${blocks.length} test${blocks.length === 1 ? "" : "s"}`);
 
     for (const block of blocks) {
       const outName = `${baseName}_${block.line}.test.${block.outputExtension}`;
       const outPath = join(outputDir, outName);
-      resolved.writeFile(outPath, renderBlockFile(relPath, block));
-      resolved.log(`  ${relPath}:${block.line} -> ${outPath}`);
-      total++;
+      writeFile(outPath, renderBlockFile(relPath, block));
+      logger.trace(`  ${relPath}:${block.line} -> ${outPath}`);
     }
   }
 
-  resolved.log(`\nTotal: ${total} tests`);
+  logger.info(`Total: ${total} tests`);
   return total;
 }

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,0 +1,49 @@
+const LOG_LEVELS = ["silent", "error", "info", "debug", "trace"] as const;
+
+export type LogLevel = (typeof LOG_LEVELS)[number];
+
+export interface Logger {
+  error: (message: string) => void;
+  info: (message: string) => void;
+  debug: (message: string) => void;
+  trace: (message: string) => void;
+}
+
+function isLogLevel(value: string): value is LogLevel {
+  return LOG_LEVELS.some((level) => level === value);
+}
+
+function isEnabled(configuredLevel: LogLevel, messageLevel: Exclude<LogLevel, "silent">): boolean {
+  return LOG_LEVELS.indexOf(configuredLevel) >= LOG_LEVELS.indexOf(messageLevel);
+}
+
+export function parseLogLevel(value: string | undefined): LogLevel {
+  if (value === undefined) return "info";
+
+  const normalized = value.trim().toLowerCase();
+  if (!isLogLevel(normalized)) {
+    throw new Error(`Invalid log level "${value}". Must be one of: ${LOG_LEVELS.join(", ")}.`);
+  }
+  return normalized;
+}
+
+export function createLogger(level: LogLevel | undefined = "info"): Logger {
+  return {
+    error: (message) => {
+      if (isEnabled(level, "error")) console.error(message);
+    },
+    info: (message) => {
+      if (isEnabled(level, "info")) console.log(message);
+    },
+    debug: (message) => {
+      if (isEnabled(level, "debug")) console.debug(message);
+    },
+    trace: (message) => {
+      if (isEnabled(level, "trace")) console.debug(message);
+    },
+  };
+}
+
+export function createLoggerFromEnv(): Logger {
+  return createLogger(parseLogLevel(process.env.DDT_LOG_LEVEL));
+}

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,9 +1,21 @@
 import type { Plugin } from "vitest/config";
-import { findDocs, generate as generateCore, type GenerateDeps } from "@ddtds/core";
+import { generate as generateCore, type GenerateDeps } from "@ddtds/core";
 import { generateBlockFile } from "./codegen.ts";
+import { createLogger, parseLogLevel } from "@ddtds/core/log";
+import type { LogLevel } from "@ddtds/core/log";
 
-export { findDocs, generateBlockFile };
 export type { CodeBlock, GenerateDeps } from "@ddtds/core";
+export type { LogLevel } from "@ddtds/core/log";
+
+export type DdtPluginOptions = {
+  /**
+   * Precedence (highest to lowest):
+   *   1. `DDT_LOG_LEVEL` environment variable
+   *   2. `logLevel` option
+   *   3. `"info"` (default)
+   */
+  logLevel?: LogLevel;
+};
 
 export function generate(
   searchDir: string,
@@ -13,11 +25,23 @@ export function generate(
   return generateCore(searchDir, outputDir, generateBlockFile, deps);
 }
 
-export function ddtPlugin(searchDir: string, outputDir: string): Plugin {
+/**
+ * @param searchDir Directory to scan for `.md` and `.mdx` files. Defaults to `"."`
+ * @param outputDir Directory to write test files. Defaults to `"__doctests__"`
+ */
+export function ddtPlugin(
+  searchDir: string = ".",
+  outputDir: string = "__doctests__",
+  options?: DdtPluginOptions,
+): Plugin {
   return {
     name: "vite-plugin-ddtds",
     config() {
-      generate(searchDir, outputDir);
+      const level = parseLogLevel(process.env.DDT_LOG_LEVEL ?? options?.logLevel);
+      const logger = createLogger(level);
+
+      generate(searchDir, outputDir, { logger });
+
       return { test: { include: [`${outputDir}/**/*.test.{ts,tsx}`] } };
     },
   };


### PR DESCRIPTION
It was real annoying to see 1000+ logs for each file created, so this PR creates a logger with log levels configurable through environment variables/config

closes #31 