### PR TITLE
feat: custom error to categorize failures 

### DIFF
--- a/examples/ts/api.md
+++ b/examples/ts/api.md
@@ -62,6 +62,14 @@ const results = await Promise.all([Promise.resolve(1), Promise.resolve(2), Promi
 expect(results).toEqual([1, 2, 3]);
 ```
 
+## Compile failure
+
+This block shows a bad TypeScript snippet that should fail to parse or compile. The doctest asserts that the invalid snippet throws.
+
+```ts compile-fail
+const hi;
+```
+
 ## Skipped example
 
 This block is intentionally broken but tagged `skip` so it won't run:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "pnpm -r test",
     "test:packages": "pnpm --filter './packages/*' run test",
     "test:examples": "pnpm --filter '@ddtds/example-*' test",
-    "test:update-snapshots": "pnpm -r test -- -u",
+    "test:update-snapshots": "pnpm -r test -u",
     "knip": "knip"
   },
   "devDependencies": {

--- a/packages/core/src/error.test.ts
+++ b/packages/core/src/error.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { DdtTestError, ErrorKind, wrapDdtTest } from "./error";
+
+describe("DdtTestError", () => {
+  test.each([
+    "const x = ;",
+    "import x from 'y'",
+    "require('x')",
+    "console.log(x)",
+    "await import('x')",
+    "window",
+    "document",
+    "React.createElement('div')",
+    "new Foo()",
+    "class X extends Y {}",
+    "const = 10",
+    "type Hi",
+    "type X<T> = true; type Y = X<>",
+  ])("rethrows as compile error: %s", async (fn) => {
+    // eslint-disable-next-line no-eval
+    const promise = wrapDdtTest(() => eval(fn));
+
+    await expect(promise).rejects.toBeInstanceOf(DdtTestError);
+    await expect(promise).rejects.toHaveProperty("kind", ErrorKind.Compile);
+  });
+
+  test.each([
+    () => expect(1).toBe(2),
+    () => {
+      throw new Error("generic");
+    },
+    () => {
+      // @ts-expect-error
+      // eslint-disable-next-line no-unused-expressions
+      null.y;
+    },
+  ])("rethrows as runtime error", async (fn) => {
+    const promise = wrapDdtTest(fn);
+
+    await expect(promise).rejects.toBeInstanceOf(DdtTestError);
+    await expect(promise).rejects.toHaveProperty("kind", ErrorKind.RuntimeFailure);
+  });
+});

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -1,0 +1,42 @@
+export const ErrorKind = {
+  Compile: "compile-error",
+  RuntimeFailure: "runtime-failure",
+} as const;
+
+export type ErrorKind = (typeof ErrorKind)[keyof typeof ErrorKind];
+
+const ERROR_MESSAGES = [
+  "Cannot use import statement outside a module",
+  "Cannot find module",
+  "is not defined",
+];
+
+function isCompileError(error: unknown): boolean {
+  if (error instanceof SyntaxError) return true;
+  if (!(error instanceof Error)) return false;
+
+  return ERROR_MESSAGES.some((message) => error.message.includes(message));
+}
+
+export class DdtTestError extends Error {
+  constructor(sourceError: unknown) {
+    const message = sourceError instanceof Error ? sourceError.message : String(sourceError);
+    super(message, { cause: sourceError });
+    this.name = "DdtTestError";
+    Object.setPrototypeOf(this, DdtTestError.prototype);
+  }
+
+  get kind(): ErrorKind {
+    return isCompileError(this.cause) ? ErrorKind.Compile : ErrorKind.RuntimeFailure;
+  }
+}
+
+export async function wrapDdtTest<ReturnType>(
+  run: () => Promise<ReturnType> | ReturnType,
+): Promise<ReturnType> {
+  try {
+    return await run();
+  } catch (error) {
+    throw new DdtTestError(error);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ import { createLoggerFromEnv, type Logger } from "./logger.ts";
 
 export { CodeBlock, parseCodeFences } from "./blocks.ts";
 export { SUPPORTED_LANGS, ANNOTATIONS } from "./constants.ts";
+export { wrapDdtTest } from "./error.ts";
 
 export function findDocs(dir: string): string[] {
   return globSync("**/*.{md,mdx}", { cwd: dir, ignore: ["**/node_modules/**"], absolute: true });

--- a/packages/vitest/src/codegen.test.ts
+++ b/packages/vitest/src/codegen.test.ts
@@ -35,10 +35,13 @@ describe("generateBlockFile: basic", () => {
     expect(output).toContain("expect(hi).toBe('10');");
 
     expect(output).toMatchInlineSnapshot(`
-      "import { test, expect } from 'vitest'
+      "import { test, expect } from 'vitest';
+      import { DdtTestError, wrapDdtTest } from '@ddtds/vitest'
       test("example.md:1", async () => {
-        const hi = '10';
-        expect(hi).toBe('10');
+        await wrapDdtTest(async () => {
+          const hi = '10';
+          expect(hi).toBe('10');
+        });
       });"
     `);
   });
@@ -51,14 +54,17 @@ describe("generateBlockFile: imports", () => {
 
     assertTestRun(out);
     expect(out).toMatchInlineSnapshot(`
-      "import { test, expect } from 'vitest'
+      "import { test, expect } from 'vitest';
+      import { DdtTestError, wrapDdtTest } from '@ddtds/vitest'
       import {
         foo,
         bar,
         baz,
       } from './utils'
       test("t.md:1", async () => {
-        foo()
+        await wrapDdtTest(async () => {
+          foo()
+        });
       });"
     `);
   });
@@ -74,11 +80,14 @@ describe("generateBlockFile: annotations", () => {
     assertTestReject(out);
     expect(out).toContain(".rejects.toThrow();");
     expect(out).toMatchInlineSnapshot(`
-      "import { test, expect } from 'vitest'
+      "import { test, expect } from 'vitest';
+      import { DdtTestError, wrapDdtTest } from '@ddtds/vitest'
       test("t.md:1", async () => {
-        await expect(async () => {
-        throw new Error("boom")
-        }).rejects.toThrow();
+        await wrapDdtTest(async () => {
+          await expect(async () => {
+            throw new Error("boom")
+          }).rejects.toThrow();
+        });
       });"
     `);
   });
@@ -89,8 +98,7 @@ describe("generateBlockFile: annotations", () => {
     assertTestSkip(noRun);
     expect(noRun).not.toContain("const x = 1");
     expect(noRun).toMatchInlineSnapshot(`
-      "import { test, expect } from 'vitest'
-      test.skip("t.md:1", async () => {
+      "import { test, expect } from 'vitest';test.skip("t.md:1", async () => {
       });"
     `);
 
@@ -99,8 +107,7 @@ describe("generateBlockFile: annotations", () => {
     assertTestSkip(compileFail);
     expect(compileFail).not.toContain("const x = 1");
     expect(compileFail).toMatchInlineSnapshot(`
-      "import { test, expect } from 'vitest'
-      test.skip("t.md:1", async () => {
+      "import { test, expect } from 'vitest';test.skip("t.md:1", async () => {
       });"
     `);
   });

--- a/packages/vitest/src/codegen.ts
+++ b/packages/vitest/src/codegen.ts
@@ -15,24 +15,25 @@ function renderTest(kind: "test" | "test.skip", name: string, body: string): str
   return `${kind}(${name}, async () => {\n${indent(body)}\n});`;
 }
 
+const VITEST_IMPORT = "import { test, expect } from 'vitest';";
+const DDT_IMPORT = "import { DdtTestError, wrapDdtTest } from '@ddtds/vitest'";
+
 export function generateBlockFile(mdPath: string, block: CodeBlock): string {
-  const { imports, body } = block.splitImports();
   const name = JSON.stringify(`${mdPath}:${block.line}`);
-
-  const headerLines = ["import { test, expect } from 'vitest'", ...imports];
-  const header = `${headerLines.join("\n")}\n`;
-
   if (block.isSkipped()) {
-    return `${header}${renderTest("test.skip", name, "")}`;
+    return VITEST_IMPORT + renderTest("test.skip", name, "");
   }
+
+  const { imports, body } = block.splitImports();
+
+  const header = [VITEST_IMPORT, DDT_IMPORT, ...imports].join("\n") + "\n";
+
+  const wrapBody = (inner: string) => `await wrapDdtTest(async () => {\n${indent(inner)}\n});`;
 
   if (block.shouldThrow()) {
-    return `${header}${renderTest(
-      "test",
-      name,
-      ["await expect(async () => {", body, "}).rejects.toThrow();"].join("\n"),
-    )}`;
+    const inner = `await expect(async () => {\n${indent(body)}\n}).rejects.toThrow();`;
+    return `${header}${renderTest("test", name, wrapBody(inner))}`;
   }
 
-  return `${header}${renderTest("test", name, body)}`;
+  return `${header}${renderTest("test", name, wrapBody(body))}`;
 }

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -5,6 +5,7 @@ import { createLogger, parseLogLevel } from "@ddtds/core/log";
 import type { LogLevel } from "@ddtds/core/log";
 
 export type { CodeBlock, GenerateDeps } from "@ddtds/core";
+export { wrapDdtTest } from "@ddtds/core";
 export type { LogLevel } from "@ddtds/core/log";
 
 export type DdtPluginOptions = {


### PR DESCRIPTION
- custom error to delineate between semantically compile time errors (missing imports, syntax errors)
- don't parse code block when skipped 

closes #34 