### PR TITLE
feat!: default to no run for codeblocks and simplify annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Must haves
 1. support vitest
 2. CLI
 3. hide boilerplate (should it be # or other syntax)
-4. annotations (compile-fail, no-run, should-throw)
+4. annotations (run, fail, skip)
 5. --max-failures to ratchet down build failures incrementally
 6. agent skill to aid with migration and fixing build failures (prefer adding hidden imports to compile, do not add assertions??)
 7. ignore config (maybe file?)

--- a/examples/js/api.md
+++ b/examples/js/api.md
@@ -6,21 +6,21 @@ Code blocks tagged `js` or `javascript` are extracted and run as vitest tests.
 
 Mapping over an array doubles each element:
 
-```js
+```js run
 const result = [1, 2, 3].map((x) => x * 2);
 expect(result).toEqual([2, 4, 6]);
 ```
 
 Filtering keeps only items that pass the predicate:
 
-```js
+```js run
 const evens = [1, 2, 3, 4, 5].filter((x) => x % 2 === 0);
 expect(evens).toEqual([2, 4]);
 ```
 
 `reduce` accumulates values:
 
-```js
+```js run
 const sum = [1, 2, 3, 4].reduce((acc, x) => acc + x, 0);
 expect(sum).toBe(10);
 ```
@@ -29,7 +29,7 @@ expect(sum).toBe(10);
 
 Template literals interpolate values:
 
-```js
+```js run
 const name = "world";
 expect(`hello ${name}`).toBe("hello world");
 ```
@@ -38,7 +38,7 @@ expect(`hello ${name}`).toBe("hello world");
 
 Spread merges objects without mutating the originals:
 
-```js
+```js run
 const base = { a: 1, b: 2 };
 const extended = { ...base, c: 3 };
 expect(extended).toEqual({ a: 1, b: 2, c: 3 });
@@ -49,16 +49,16 @@ expect(base).toEqual({ a: 1, b: 2 });
 
 `Promise.all` resolves when every promise settles:
 
-```js
+```js run
 const results = await Promise.all([Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)]);
 expect(results).toEqual([1, 2, 3]);
 ```
 
 ## Expected throw
 
-Use `should-throw` when a block is expected to throw:
+Use `fail` when a block is expected to throw:
 
-```js should-throw
+```js fail
 throw new Error("boom");
 ```
 

--- a/examples/react/components.mdx
+++ b/examples/react/components.mdx
@@ -1,10 +1,10 @@
 # Component Examples
 
-Blocks tagged `tsx` are run as tests with `@testing-library/react`.
+Blocks tagged `tsx run` are run as tests with `@testing-library/react`.
 
 ## Rendering
 
-```tsx
+```tsx run
 import { render, screen } from "@testing-library/react";
 function Greeting({ name }: { name: string }) {
   return <p>Hello, {name}!</p>;
@@ -15,7 +15,7 @@ expect(screen.getByText("Hello, world!")).toBeInTheDocument();
 
 Query by accessible role:
 
-```tsx
+```tsx run
 import { render, screen } from "@testing-library/react";
 function SaveButton() {
   return <button type="submit">Save</button>;
@@ -29,7 +29,7 @@ expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
 `fireEvent` triggers synthetic DOM events. Uncontrolled inputs track their own
 state in the DOM, so no React state is needed for a basic toggle assertion:
 
-```tsx
+```tsx run
 import { render, screen, fireEvent } from "@testing-library/react";
 render(<input type="checkbox" aria-label="accept" />);
 const box = screen.getByRole("checkbox", { name: "accept" });

--- a/examples/ts/api.md
+++ b/examples/ts/api.md
@@ -1,78 +1,29 @@
 # API Examples
 
 Code blocks tagged `ts` or `typescript` are extracted and run as vitest tests.
-Add `skip` after the lang tag to exclude a block.
-
-## Arrays
-
-Mapping over an array doubles each element:
-
-```ts
-const result = [1, 2, 3].map((x) => x * 2);
-expect(result).toEqual([2, 4, 6]);
-```
-
-Filtering keeps only items that pass the predicate:
-
-```ts
-const evens = [1, 2, 3, 4, 5].filter((x) => x % 2 === 0);
-expect(evens).toEqual([2, 4]);
-```
-
-`reduce` accumulates values:
-
-```ts
-const sum = [1, 2, 3, 4].reduce((acc, x) => acc + x, 0);
-expect(sum).toBe(10);
-```
+Add `run` after the lang tag to include a block as a test.
 
 ## Strings
 
 Template literals interpolate values:
 
-```ts
+```ts run
 const name = "world";
 expect(`hello ${name}`).toBe("hello world");
-```
-
-`String.prototype.split` turns a string into tokens:
-
-```ts
-const parts = "a,b,c".split(",");
-expect(parts).toEqual(["a", "b", "c"]);
-```
-
-## Objects
-
-Spread merges objects without mutating the originals:
-
-```ts
-const base = { a: 1, b: 2 };
-const extended = { ...base, c: 3 };
-expect(extended).toEqual({ a: 1, b: 2, c: 3 });
-expect(base).toEqual({ a: 1, b: 2 });
 ```
 
 ## Async
 
 `Promise.all` resolves when every promise settles:
 
-```ts
+```ts run
 const results = await Promise.all([Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)]);
 expect(results).toEqual([1, 2, 3]);
 ```
 
-## Compile failure
-
-This block shows a bad TypeScript snippet that should fail to parse or compile. The doctest asserts that the invalid snippet throws.
-
-```ts compile-fail
-const hi;
-```
-
 ## Skipped example
 
-This block is intentionally broken but tagged `skip` so it won't run:
+This block is intentionally excluded from tests with `skip`:
 
 ```ts skip
 expect(1).toBe(999);

--- a/examples/ts/codegen-edge-cases.md
+++ b/examples/ts/codegen-edge-cases.md
@@ -6,7 +6,7 @@ These snippets cover import and export transformations used when generating doct
 
 Named imports from Node builtins should still work after import extraction and hoisting.
 
-```ts
+```ts run
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -18,7 +18,7 @@ expect(join(dir, "child")).toContain("child");
 
 Export modifiers on runtime declarations should be sanitized without changing behavior.
 
-```ts
+```ts run
 export const base = 2;
 export function addOne(x: number): number {
   return x + 1;
@@ -41,7 +41,7 @@ expect(c.value).toBe(1);
 
 `export default class` should be rewritten without leaving invalid syntax.
 
-```ts
+```ts run
 export default class Greeter {
   constructor(private readonly name: string) {}
 
@@ -56,7 +56,7 @@ expect(g.greet()).toBe("hello world");
 
 ## Declare Is Fine
 
-```ts
+```ts run
 declare const neverDefined: number;
 
 const safe = 1;
@@ -67,7 +67,7 @@ expect(safe).toBe(1);
 
 Type-only declarations should survive type-checking and not affect runtime assertions.
 
-```ts
+```ts run
 export interface User {
   id: string;
 }
@@ -85,7 +85,7 @@ expect(users.a?.id).toBe("a");
 
 Default export expressions should be rewritten so they are valid inside the generated test function body.
 
-```ts
+```ts run
 export default { answer: 42 };
 
 expect(1 + 1).toBe(2);
@@ -95,7 +95,7 @@ expect(1 + 1).toBe(2);
 
 Named export lists should be removed from the test body while keeping surrounding runtime code.
 
-```ts
+```ts run
 const foo = "ok";
 export { foo };
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -15,7 +15,7 @@ describe("generate", () => {
     const total = generate("/repo", "__doctests__", {
       findDocs: () => ["/repo/guide.md", "/repo/empty.md"],
       readFile: (path) => {
-        if (path.endsWith("guide.md")) return "```ts\nconst x = 1\n```";
+        if (path.endsWith("guide.md")) return "```ts run\nconst x = 1\n```";
         return "# prose only";
       },
       writeFile: (path, content) => writes.push({ path, content }),

--- a/packages/core/src/blocks.bench.ts
+++ b/packages/core/src/blocks.bench.ts
@@ -37,6 +37,6 @@ expect(new Greeter("world").greet()).toBe("hello world");`;
 
 describe("CodeBlock.splitImports", () => {
   bench("split imports and sanitize block", () => {
-    new CodeBlock(code, "ts", "", 1).splitImports();
+    new CodeBlock(code, "ts", null, 1).splitImports();
   });
 });

--- a/packages/core/src/blocks.ts
+++ b/packages/core/src/blocks.ts
@@ -1,18 +1,30 @@
 import { remark } from "remark";
 import { visit } from "unist-util-visit";
-import { SUPPORTED_LANGS, ANNOTATIONS } from "./constants.ts";
+import { SUPPORTED_LANGS, ANNOTATIONS, type Annotation, isAnnotation } from "./constants.ts";
 import { splitImportsAndBlock } from "./parse.ts";
+import { type Logger } from "./logger.ts";
+
+type AnnotationResult =
+  | { tag: "ok"; annotation: Annotation }
+  | { tag: "none" }
+  | { tag: "unknown"; raw: string };
+
+function parseAnnotation(meta: string): AnnotationResult {
+  if (!meta) return { tag: "none" };
+  if (isAnnotation(meta)) return { tag: "ok", annotation: meta };
+  return { tag: "unknown", raw: meta };
+}
 
 export class CodeBlock {
   readonly #code: string;
   readonly lang: string;
-  readonly #meta: string;
+  readonly #annotation: Annotation | null;
   readonly line: number;
 
-  constructor(code: string, lang: string, meta: string | null | undefined, line: number) {
+  constructor(code: string, lang: string, annotation: Annotation | null, line: number) {
     this.#code = code;
     this.lang = lang;
-    this.#meta = meta ?? "";
+    this.#annotation = annotation;
     this.line = line;
   }
 
@@ -29,11 +41,11 @@ export class CodeBlock {
   }
 
   isSkipped(): boolean {
-    return this.#meta.includes(ANNOTATIONS.NO_RUN) || this.#meta.includes(ANNOTATIONS.COMPILE_FAIL);
+    return this.#annotation !== ANNOTATIONS.RUN && this.#annotation !== ANNOTATIONS.FAIL;
   }
 
-  shouldThrow(): boolean {
-    return this.#meta.includes(ANNOTATIONS.SHOULD_THROW);
+  shouldFail(): boolean {
+    return this.#annotation === ANNOTATIONS.FAIL;
   }
 
   splitImports(): { imports: string[]; body: string } {
@@ -41,16 +53,21 @@ export class CodeBlock {
   }
 }
 
-export function parseCodeFences(source: string): CodeBlock[] {
+export function parseCodeFences(source: string, log: Logger): CodeBlock[] {
   const tree = remark().parse(source);
   const blocks: CodeBlock[] = [];
 
   visit(tree, "code", (node) => {
     const { lang, meta } = node;
-    if (!lang || !SUPPORTED_LANGS.has(lang)) return;
-    if ((meta ?? "").split(" ").includes(ANNOTATIONS.SKIP)) return;
+    if (!meta || !lang || !SUPPORTED_LANGS.has(lang)) return;
 
-    blocks.push(new CodeBlock(node.value, lang, meta, node.position!.start.line));
+    const result = parseAnnotation(meta);
+    if (result.tag === "unknown") {
+      log.error(`unknown annotation in code block: "${result.raw}"`);
+      return;
+    }
+    if (result.tag === "none" || result.annotation === ANNOTATIONS.SKIP) return;
+    blocks.push(new CodeBlock(node.value, lang, result.annotation, node.position!.start.line));
   });
 
   return blocks;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -2,7 +2,12 @@ export const SUPPORTED_LANGS = new Set(["ts", "typescript", "tsx", "jsx", "js", 
 
 export const ANNOTATIONS = {
   SKIP: "skip",
-  NO_RUN: "no-run",
-  COMPILE_FAIL: "compile-fail",
-  SHOULD_THROW: "should-throw",
+  RUN: "run",
+  FAIL: "fail",
 } as const;
+
+export type Annotation = (typeof ANNOTATIONS)[keyof typeof ANNOTATIONS];
+
+export function isAnnotation(s: unknown): s is Annotation {
+  return Object.values(ANNOTATIONS).some((x) => x === s);
+}

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,40 +1,95 @@
 import { describe, test, expect, vi } from "vitest";
-import { ANNOTATIONS, CodeBlock, parseCodeFences, generate } from "./index";
+import { ANNOTATIONS, CodeBlock, parseCodeFences, generate, type Annotation } from "./index";
+import { createLogger } from "./logger";
+
+const silent = createLogger("silent");
 
 describe("parseBlocks", () => {
-  test("extracts ts blocks", () => {
-    const blocks = parseCodeFences("```ts\nconst x = 1\n```");
+  test.each([
+    ["ts", ANNOTATIONS.RUN],
+    ["typescript", ANNOTATIONS.RUN],
+    ["tsx", ANNOTATIONS.RUN],
+    ["jsx", ANNOTATIONS.RUN],
+    ["ts", ANNOTATIONS.FAIL],
+  ])("collects %s blocks annotated %s", (lang, annotation) => {
+    const blocks = parseCodeFences(`\`\`\`${lang} ${annotation}\nconst x = 1\n\`\`\``, silent);
     expect(blocks).toHaveLength(1);
-    expect(blocks[0]!).toMatchObject({ lang: "ts", line: 1 });
+    expect(blocks[0]!).toMatchObject({ lang });
   });
 
-  test("extracts typescript blocks", () => {
-    expect(parseCodeFences("```typescript\nconst x = 1\n```")).toHaveLength(1);
-  });
-
-  test("extracts jsx/tsx blocks", () => {
-    const tsx = parseCodeFences("```tsx\n<div />\n```");
-    const jsx = parseCodeFences("```jsx\n<div />\n```");
-    expect(tsx[0]!).toMatchObject({ lang: "tsx" });
-    expect(jsx[0]!).toMatchObject({ lang: "jsx" });
-  });
-
-  test("ignores unsupported langs", () => {
-    expect(parseCodeFences("```python\nx = 1\n```")).toHaveLength(0);
-  });
-
-  test("skips blocks annotated skip", () => {
-    expect(parseCodeFences(`\`\`\`ts ${ANNOTATIONS.SKIP}\nconst x = 1\n\`\`\``)).toHaveLength(0);
-  });
-
-  test("preserves meta string verbatim", () => {
-    const [b] = parseCodeFences(`\`\`\`ts ${ANNOTATIONS.SHOULD_THROW}\nthrow new Error()\n\`\`\``);
-    expect(b!.shouldThrow()).toBe(true);
+  test.each([
+    ["ts", ""],
+    ["ts", ANNOTATIONS.SKIP],
+    ["ts", "unrecognized"],
+    ["ts", `${ANNOTATIONS.SKIP} other`],
+    ["python", ANNOTATIONS.RUN],
+  ])("excludes %s blocks with meta %j", (lang, meta) => {
+    const src = meta
+      ? `\`\`\`${lang} ${meta}\nconst x = 1\n\`\`\``
+      : `\`\`\`${lang}\nconst x = 1\n\`\`\``;
+    expect(parseCodeFences(src, silent)).toHaveLength(0);
   });
 });
 
-function block(code: string, meta = "", line = 1, lang = "ts"): CodeBlock {
-  return new CodeBlock(code, lang, meta, line);
+describe("CodeBlock.isSkipped / shouldFail", () => {
+  test.each([
+    [null, true, false],
+    [ANNOTATIONS.SKIP, true, false],
+    [ANNOTATIONS.RUN, false, false],
+    [ANNOTATIONS.FAIL, false, true],
+  ] as const)(
+    "annotation=%j → isSkipped=%s shouldFail=%s",
+    (annotation, expectedSkipped, expectedFail) => {
+      const b = new CodeBlock("x", "ts", annotation, 1);
+      expect(b.isSkipped()).toBe(expectedSkipped);
+      expect(b.shouldFail()).toBe(expectedFail);
+    },
+  );
+});
+
+describe("CodeBlock.outputExtension / isJsx", () => {
+  test.each([
+    ["ts", "ts", false],
+    ["typescript", "ts", false],
+    ["js", "ts", false],
+    ["javascript", "ts", false],
+    ["tsx", "tsx", true],
+    ["jsx", "tsx", true],
+  ])("lang=%j → outputExtension=%j isJsx=%s", (lang, ext, jsx) => {
+    const b = new CodeBlock("x", lang, ANNOTATIONS.RUN, 1);
+    expect(b.outputExtension).toBe(ext);
+    expect(b.isJsx()).toBe(jsx);
+  });
+});
+
+describe("parseBlocks: line numbers", () => {
+  test("records correct line for each block in multi-block source", () => {
+    const source = [
+      "```ts run",
+      "const a = 1",
+      "```",
+      "",
+      "prose",
+      "",
+      "```ts run",
+      "const b = 2",
+      "```",
+    ].join("\n");
+
+    const blocks = parseCodeFences(source, silent);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.line).toBe(1);
+    expect(blocks[1]!.line).toBe(7);
+  });
+});
+
+function block(
+  code: string,
+  annotation: Annotation | null = null,
+  line = 1,
+  lang = "ts",
+): CodeBlock {
+  return new CodeBlock(code, lang, annotation, line);
 }
 
 describe("CodeBlock.splitImports", () => {
@@ -73,7 +128,7 @@ describe("generate", () => {
     const writes: Array<{ path: string; content: string }> = [];
     const total = generate("/repo", "__doctests__", renderBlockFile, {
       findDocs: () => ["/repo/guide.md"],
-      readFile: () => "```ts\nconst x = 1\n```",
+      readFile: () => "```ts run\nconst x = 1\n```",
       writeFile: (path, content) => writes.push({ path, content }),
       clearDir: vi.fn<() => void>(),
     });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@ import { parseCodeFences, type CodeBlock } from "./blocks.ts";
 import { createLoggerFromEnv, type Logger } from "./logger.ts";
 
 export { CodeBlock, parseCodeFences } from "./blocks.ts";
-export { SUPPORTED_LANGS, ANNOTATIONS } from "./constants.ts";
+export { SUPPORTED_LANGS, ANNOTATIONS, type Annotation } from "./constants.ts";
 export { wrapDdtTest } from "./error.ts";
 
 export function findDocs(dir: string): string[] {
@@ -51,7 +51,7 @@ export function generate(
 
   for (const mdPath of docs) {
     const source = readFile(mdPath);
-    const blocks = parseCodeFences(source);
+    const blocks = parseCodeFences(source, logger);
     if (blocks.length === 0) continue;
     total += blocks.length;
 

--- a/packages/vitest/src/codegen.test.ts
+++ b/packages/vitest/src/codegen.test.ts
@@ -1,20 +1,19 @@
 import { describe, expect, test } from "vitest";
-import { ANNOTATIONS, CodeBlock } from "@ddtds/core";
+import { ANNOTATIONS, CodeBlock, type Annotation } from "@ddtds/core";
 import { generateBlockFile } from "./codegen";
 
-function block(code: string, meta = "", line = 1, lang = "ts"): CodeBlock {
-  return new CodeBlock(code, lang, meta, line);
+function block(
+  code: string,
+  annotation: Annotation | null = null,
+  line = 1,
+  lang = "ts",
+): CodeBlock {
+  return new CodeBlock(code, lang, annotation, line);
 }
 
 function assertTestRun(x: string) {
   expect(x).toContain("test");
   expect(x).not.toContain("skip");
-  expect(x).not.toContain("reject");
-}
-
-function assertTestSkip(x: string) {
-  expect(x).toContain("test");
-  expect(x).toContain("skip");
   expect(x).not.toContain("reject");
 }
 
@@ -71,11 +70,14 @@ describe("generateBlockFile: imports", () => {
 });
 
 describe("generateBlockFile: annotations", () => {
-  test("should throw wraps in rejects.toThrow", () => {
-    const out = generateBlockFile(
-      "t.md",
-      block('throw new Error("boom")', ANNOTATIONS.SHOULD_THROW),
-    );
+  test("run annotation generates plain test", () => {
+    const out = generateBlockFile("t.md", block("expect(1).toBe(1)", ANNOTATIONS.RUN));
+    assertTestRun(out);
+    expect(out).not.toContain("rejects");
+  });
+
+  test("fail annotation wraps in rejects.toThrow", () => {
+    const out = generateBlockFile("t.md", block('throw new Error("boom")', ANNOTATIONS.FAIL));
 
     assertTestReject(out);
     expect(out).toContain(".rejects.toThrow();");
@@ -88,26 +90,6 @@ describe("generateBlockFile: annotations", () => {
             throw new Error("boom")
           }).rejects.toThrow();
         });
-      });"
-    `);
-  });
-
-  test("skip annotations emit test.skip", () => {
-    const noRun = generateBlockFile("t.md", block("const x = 1", ANNOTATIONS.NO_RUN));
-
-    assertTestSkip(noRun);
-    expect(noRun).not.toContain("const x = 1");
-    expect(noRun).toMatchInlineSnapshot(`
-      "import { test, expect } from 'vitest';test.skip("t.md:1", async () => {
-      });"
-    `);
-
-    const compileFail = generateBlockFile("t.md", block("const x = 1", ANNOTATIONS.COMPILE_FAIL));
-
-    assertTestSkip(compileFail);
-    expect(compileFail).not.toContain("const x = 1");
-    expect(compileFail).toMatchInlineSnapshot(`
-      "import { test, expect } from 'vitest';test.skip("t.md:1", async () => {
       });"
     `);
   });

--- a/packages/vitest/src/codegen.ts
+++ b/packages/vitest/src/codegen.ts
@@ -20,17 +20,11 @@ const DDT_IMPORT = "import { DdtTestError, wrapDdtTest } from '@ddtds/vitest'";
 
 export function generateBlockFile(mdPath: string, block: CodeBlock): string {
   const name = JSON.stringify(`${mdPath}:${block.line}`);
-  if (block.isSkipped()) {
-    return VITEST_IMPORT + renderTest("test.skip", name, "");
-  }
-
   const { imports, body } = block.splitImports();
-
   const header = [VITEST_IMPORT, DDT_IMPORT, ...imports].join("\n") + "\n";
-
   const wrapBody = (inner: string) => `await wrapDdtTest(async () => {\n${indent(inner)}\n});`;
 
-  if (block.shouldThrow()) {
+  if (block.shouldFail()) {
     const inner = `await expect(async () => {\n${indent(body)}\n}).rejects.toThrow();`;
     return `${header}${renderTest("test", name, wrapBody(inner))}`;
   }


### PR DESCRIPTION
- simplify annotations to run, fail, skip
- default to not running codeblocks

This collapses `skip` and `compile-fail`. I did that because we can't reliably catch transformation errors without hooking into the user's compiler

closes #51 